### PR TITLE
fix: update check on app open, update notification, and re-check button

### DIFF
--- a/app-client/src/main/java/com/dilinkauto/client/MainActivity.kt
+++ b/app-client/src/main/java/com/dilinkauto/client/MainActivity.kt
@@ -68,6 +68,11 @@ class MainActivity : ComponentActivity() {
             startConnectionService()
         }
 
+        // Check for updates every time the app is opened
+        if (onboardingCompleted) {
+            UpdateManager.checkForUpdate(force = true)
+        }
+
         setContent {
             DiLinkAutoTheme {
                 val installStatus by ConnectionService.installStatusFlow.collectAsState()
@@ -100,7 +105,9 @@ class MainActivity : ComponentActivity() {
                             onStopService = { stopConnectionService() },
                             onInstallOnCar = { ip -> installOnCar(ip) },
                             onOpenSettings = { showSettings = true },
-                            onShareLogs = { shareLogs() }
+                            onShareLogs = { shareLogs() },
+                            onDownloadUpdate = { UpdateManager.downloadUpdate() },
+                            onInstallUpdate = { UpdateManager.installUpdate(this) }
                         )
                     }
                 }
@@ -646,11 +653,16 @@ fun MainScreen(
     onStopService: () -> Unit,
     onInstallOnCar: (String?) -> Unit,
     onOpenSettings: () -> Unit,
-    onShareLogs: () -> Unit
+    onShareLogs: () -> Unit,
+    onDownloadUpdate: () -> Unit,
+    onInstallUpdate: () -> Unit
 ) {
     val serviceState by ConnectionService.serviceState.collectAsState()
     val installStatus by ConnectionService.installStatusFlow.collectAsState()
+    val updateState by UpdateManager.updateState.collectAsState()
+    val downloadProgress by UpdateManager.downloadProgress.collectAsState()
     val isRunning = serviceState != ConnectionService.State.IDLE
+    var updateDismissed by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -686,6 +698,100 @@ fun MainScreen(
 
         // Service status
         StatusCard(serviceState)
+
+        // Update available notification
+        if (updateState is UpdateState.Available && !updateDismissed) {
+            val available = updateState as UpdateState.Available
+            Spacer(Modifier.height(12.dp))
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = Color(0xFF1B3A2A))
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(Icons.Default.Download, contentDescription = null, tint = Color(0xFF4CAF50), modifier = Modifier.size(24.dp))
+                        Spacer(Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(stringResource(R.string.updates_available_title), fontWeight = FontWeight.Medium, color = Color.White)
+                            Text(stringResource(R.string.updates_available, available.version), fontSize = 13.sp, color = Color(0xFFB0BEC5))
+                        }
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Button(
+                            onClick = onDownloadUpdate,
+                            modifier = Modifier.weight(1f),
+                            shape = RoundedCornerShape(12.dp),
+                            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF4CAF50))
+                        ) {
+                            Icon(Icons.Default.Download, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Spacer(Modifier.width(8.dp))
+                            Text(stringResource(R.string.updates_update_btn))
+                        }
+                        OutlinedButton(
+                            onClick = { updateDismissed = true },
+                            modifier = Modifier.weight(1f),
+                            shape = RoundedCornerShape(12.dp)
+                        ) {
+                            Text(stringResource(R.string.updates_dismiss_btn), color = Color.Gray)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Download progress
+        if (updateState is UpdateState.Downloading) {
+            val downloading = updateState as UpdateState.Downloading
+            Spacer(Modifier.height(12.dp))
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(stringResource(R.string.updates_downloading_title, downloading.version), fontWeight = FontWeight.Medium, color = Color.White)
+                    Spacer(Modifier.height(8.dp))
+                    LinearProgressIndicator(progress = downloadProgress / 100f, modifier = Modifier.fillMaxWidth(), color = MaterialTheme.colorScheme.primary, trackColor = Color(0xFF30363D))
+                    Spacer(Modifier.height(4.dp))
+                    Text(stringResource(R.string.updates_downloading, downloadProgress), fontSize = 13.sp, color = Color.Gray)
+                }
+            }
+        }
+
+        // Ready to install
+        if (updateState is UpdateState.ReadyToInstall) {
+            val ready = updateState as UpdateState.ReadyToInstall
+            Spacer(Modifier.height(12.dp))
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = Color(0xFF1B3A2A))
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(Icons.Default.CheckCircle, contentDescription = null, tint = Color(0xFF4CAF50), modifier = Modifier.size(24.dp))
+                        Spacer(Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(stringResource(R.string.updates_ready_title), fontWeight = FontWeight.Medium, color = Color.White)
+                            Text(stringResource(R.string.updates_ready, ready.version), fontSize = 13.sp, color = Color(0xFFB0BEC5))
+                        }
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    Button(
+                        onClick = onInstallUpdate,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF4CAF50))
+                    ) {
+                        Icon(Icons.Default.InstallMobile, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(Modifier.width(8.dp))
+                        Text(stringResource(R.string.updates_install_btn))
+                    }
+                }
+            }
+        }
 
         Spacer(Modifier.height(12.dp))
 
@@ -1043,6 +1149,10 @@ fun UpdatesCard(
                 }
                 is UpdateState.UpToDate -> {
                     Text(stringResource(R.string.updates_up_to_date, state.version), fontSize = 13.sp, color = Color(0xFF4CAF50))
+                    Spacer(Modifier.height(8.dp))
+                    TextButton(onClick = onCheckForUpdate) {
+                        Text(stringResource(R.string.updates_check_phone), color = MaterialTheme.colorScheme.primary)
+                    }
                 }
                 is UpdateState.Available -> {
                     Text(stringResource(R.string.updates_available, state.version), fontSize = 13.sp, color = Color(0xFFFFA726))

--- a/app-client/src/main/res/values-be/strings.xml
+++ b/app-client/src/main/res/values-be/strings.xml
@@ -53,6 +53,11 @@
     <string name="updates_ready">Тэлефон: v%1$s гатова</string>
     <string name="updates_install_btn">Усталяваць абнаўленне</string>
     <string name="updates_retry">Паўтарыць</string>
+    <string name="updates_available_title">Даступна абнаўленне</string>
+    <string name="updates_update_btn">Абнавіць</string>
+    <string name="updates_dismiss_btn">Прапусціць</string>
+    <string name="updates_downloading_title">Загрузка абнаўлення v%1$s</string>
+    <string name="updates_ready_title">Гатова да ўстаноўкі</string>
     <string name="updates_car_title">Праграма аўто</string>
     <string name="updates_car_desc">Усталяваць або абнавіць праграму аўто праз WiFi ADB</string>
     <string name="updates_car_install">Усталяваць</string>

--- a/app-client/src/main/res/values-fr/strings.xml
+++ b/app-client/src/main/res/values-fr/strings.xml
@@ -53,6 +53,11 @@
     <string name="updates_ready">Téléphone : v%1$s prête</string>
     <string name="updates_install_btn">Installer la mise à jour</string>
     <string name="updates_retry">Réessayer</string>
+    <string name="updates_available_title">Mise à jour disponible</string>
+    <string name="updates_update_btn">Mettre à jour</string>
+    <string name="updates_dismiss_btn">Ignorer</string>
+    <string name="updates_downloading_title">Téléchargement de la mise à jour v%1$s</string>
+    <string name="updates_ready_title">Prêt à installer</string>
     <string name="updates_car_title">Appli Voiture</string>
     <string name="updates_car_desc">Installer ou mettre à jour l\'appli voiture via WiFi ADB</string>
     <string name="updates_car_install">Installer</string>

--- a/app-client/src/main/res/values-kk/strings.xml
+++ b/app-client/src/main/res/values-kk/strings.xml
@@ -53,6 +53,11 @@
     <string name="updates_ready">Телефон: v%1$s дайын</string>
     <string name="updates_install_btn">Жаңартуды орнату</string>
     <string name="updates_retry">Қайталау</string>
+    <string name="updates_available_title">Жаңарту қолжетімді</string>
+    <string name="updates_update_btn">Жаңарту</string>
+    <string name="updates_dismiss_btn">Өткізу</string>
+    <string name="updates_downloading_title">Жаңарту v%1$s жүктелуде</string>
+    <string name="updates_ready_title">Орнатуға дайын</string>
     <string name="updates_car_title">Автокөлік қолданбасы</string>
     <string name="updates_car_desc">Автокөлік қолданбасын WiFi ADB арқылы орнату немесе жаңарту</string>
     <string name="updates_car_install">Орнату</string>

--- a/app-client/src/main/res/values-pt-rBR/strings.xml
+++ b/app-client/src/main/res/values-pt-rBR/strings.xml
@@ -53,6 +53,11 @@
     <string name="updates_ready">Telefone: v%1$s pronto</string>
     <string name="updates_install_btn">Instalar Atualização</string>
     <string name="updates_retry">Tentar Novamente</string>
+    <string name="updates_available_title">Atualização Disponível</string>
+    <string name="updates_update_btn">Atualizar</string>
+    <string name="updates_dismiss_btn">Dispensar</string>
+    <string name="updates_downloading_title">Baixando Atualização v%1$s</string>
+    <string name="updates_ready_title">Pronto para Instalar</string>
     <string name="updates_car_title">App do Carro</string>
     <string name="updates_car_desc">Instalar ou atualizar o app do carro via WiFi ADB</string>
     <string name="updates_car_install">Instalar</string>

--- a/app-client/src/main/res/values-ru/strings.xml
+++ b/app-client/src/main/res/values-ru/strings.xml
@@ -53,6 +53,11 @@
     <string name="updates_ready">Телефон: v%1$s готово</string>
     <string name="updates_install_btn">Установить обновление</string>
     <string name="updates_retry">Повторить</string>
+    <string name="updates_available_title">Доступно обновление</string>
+    <string name="updates_update_btn">Обновить</string>
+    <string name="updates_dismiss_btn">Пропустить</string>
+    <string name="updates_downloading_title">Загрузка обновления v%1$s</string>
+    <string name="updates_ready_title">Готово к установке</string>
     <string name="updates_car_title">Приложение авто</string>
     <string name="updates_car_desc">Установить или обновить приложение авто по WiFi ADB</string>
     <string name="updates_car_install">Установить</string>

--- a/app-client/src/main/res/values-uk/strings.xml
+++ b/app-client/src/main/res/values-uk/strings.xml
@@ -53,6 +53,11 @@
     <string name="updates_ready">Телефон: v%1$s готова</string>
     <string name="updates_install_btn">Встановити оновлення</string>
     <string name="updates_retry">Повторити</string>
+    <string name="updates_available_title">Доступне оновлення</string>
+    <string name="updates_update_btn">Оновити</string>
+    <string name="updates_dismiss_btn">Пропустити</string>
+    <string name="updates_downloading_title">Завантаження оновлення v%1$s</string>
+    <string name="updates_ready_title">Готово до встановлення</string>
     <string name="updates_car_title">Застосунок авто</string>
     <string name="updates_car_desc">Встановіть або оновіть застосунок авто через WiFi ADB</string>
     <string name="updates_car_install">Встановити</string>

--- a/app-client/src/main/res/values-uz/strings.xml
+++ b/app-client/src/main/res/values-uz/strings.xml
@@ -53,6 +53,11 @@
     <string name="updates_ready">Telefon: v%1$s tayyor</string>
     <string name="updates_install_btn">Yangilanishni o\'rnatish</string>
     <string name="updates_retry">Qayta urinish</string>
+    <string name="updates_available_title">Yangilanish mavjud</string>
+    <string name="updates_update_btn">Yangilash</string>
+    <string name="updates_dismiss_btn">O‘tkazib yuborish</string>
+    <string name="updates_downloading_title">Yangilanish v%1$s yuklanmoqda</string>
+    <string name="updates_ready_title">O‘rnatishga tayyor</string>
     <string name="updates_car_title">Avtomobil ilovasi</string>
     <string name="updates_car_desc">Avtomobil ilovasini WiFi ADB orqali o\'rnating yoki yangilang</string>
     <string name="updates_car_install">O\'rnatish</string>

--- a/app-client/src/main/res/values/strings.xml
+++ b/app-client/src/main/res/values/strings.xml
@@ -53,6 +53,11 @@
     <string name="updates_ready">Phone: v%1$s ready</string>
     <string name="updates_install_btn">Install Update</string>
     <string name="updates_retry">Retry</string>
+    <string name="updates_available_title">Update Available</string>
+    <string name="updates_update_btn">Update</string>
+    <string name="updates_dismiss_btn">Dismiss</string>
+    <string name="updates_downloading_title">Downloading Update v%1$s</string>
+    <string name="updates_ready_title">Ready to Install</string>
     <string name="updates_car_title">Car App</string>
     <string name="updates_car_desc">Install or update the car app over WiFi ADB</string>
     <string name="updates_car_install">Install</string>


### PR DESCRIPTION
## Summary
- Auto-check for updates every time the app opens (force=true), bypassing the 6-hour cooldown
- Show update notification card on main screen with Update/Dismiss buttons when an update is available
- Show download progress and ready-to-install cards on main screen
- Keep "Check for phone update" button visible in settings even when up-to-date
- Translate new update UI strings to all 7 supported languages

## Files changed
- `app-client/src/main/java/com/dilinkauto/client/MainActivity.kt`
- `app-client/src/main/res/values/strings.xml`
- `app-client/src/main/res/values-*/strings.xml` (pt-BR, ru, be, fr, kk, uk, uz)

Closes #22